### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ To run the application locally:
 
 Clone the project
 ```
-git clone git@github.com:jcrosswh/SpringBootDocker.git
+git clone https://github.com/jcrosswh/SpringBootDocker.git
 ```
 Build the JAR
 ```


### PR DESCRIPTION
fix clone command; the error is shown below.

```
$ git clone git@github.com:jcrosswh/SpringBootDocker.git
Cloning into 'SpringBootDocker'...
Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
```